### PR TITLE
Add timeout for DNS to update

### DIFF
--- a/dnsimple_hook.rb
+++ b/dnsimple_hook.rb
@@ -34,7 +34,8 @@ def setup_dns(account_id, domain, subdomain_name, txt_challenge)
   acme_domain = "_acme-challenge."+subdomain_name
 
   begin
-    @client.zones.create_record(account_id, domain, name: acme_domain, type: "TXT", content: txt_challenge)
+    @client.zones.create_record(account_id, domain, name: acme_domain, type: "TXT", ttl: 60, content: txt_challenge)
+    sleep(5)
   rescue Dnsimple::RequestError => text
     # Catch Error 'Zone record already exists'
     puts text


### PR DESCRIPTION
Fixes #4 

Add timeout to allow DNSimple to update records before checking for the entry. This fixes a race condition where this script checks for the entry before the DNS entry is added.