### PR TITLE
replace sleep with verify_record

### DIFF
--- a/dnsimple_hook.rb
+++ b/dnsimple_hook.rb
@@ -50,7 +50,7 @@ def setup_dns(account_id, domain, subdomain_name, txt_challenge)
      print "."
      sleep 10;
     end
-    rescue Dnsimple::RequestError => text
+  rescue Dnsimple::RequestError => text
     # Catch Error 'Zone record already exists'
     puts text
   end


### PR DESCRIPTION
Replace sleep with verify_record method

Instead of **hoping** that 10 seconds is enough for the DNS record to propagate, instead use DNS to see if it's propagated. Only release the flow if it has finished it's propagation. This should help prevent against Let's Encrypt validation failures.

My own testing showed propagation as fast as 20 seconds, and as slow as 3 minutes.
7ee8a23
