### PR TITLE
handle domains.txt files with root domain entries

### DIFF
--- a/dnsimple_hook.rb
+++ b/dnsimple_hook.rb
@@ -44,8 +44,8 @@ def verify_record(challenge_fqdn, challenge)
 end
   
 def setup_dns(account_id, domain, subdomain_name, txt_challenge)
-  acme_domain = "_acme-challenge."+subdomain_name
-
+  acme_domain = if subdomain_name then "_acme-challenge." + subdomain_name else "_acme-challenge" end
+  
   begin
     @client.zones.create_record(account_id, domain, name: acme_domain, type: "TXT", ttl: 60, content: txt_challenge)
     puts "waiting for domain propogation"


### PR DESCRIPTION
@osowskit - When attempting to use this great hook with a `domains.txt` file to automagically handle all necessary entries for GHE with subdomain isolation I was getting an error for the top level domain `mygheinstance.com`.

This PR fixes the hook to handle entries in a `domains.txt` file without a subdomain.